### PR TITLE
Increase readability of slides

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,28 @@
       text-align: center;
       z-index: 1000;
     }
+
+    /* Przyciemnij tło slajdów z obrazkiem, by tekst był czytelny */
+    .reveal .slides section[data-background-image],
+    .reveal .slides section[data-bg-random] {
+      position: relative;
+    }
+    .reveal .slides section[data-background-image]::before,
+    .reveal .slides section[data-bg-random]::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(255, 255, 255, 0.5);
+      z-index: 1;
+    }
+    .reveal .slides section[data-background-image] > *,
+    .reveal .slides section[data-bg-random] > * {
+      position: relative;
+      z-index: 2;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add overlay in CSS to lighten background images on slides

## Testing
- `npm start` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6881ec062fd48331ad1b18af24d1e7f4