### PR TITLE
Add Gemini chat integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,17 +25,49 @@
     .reveal section li {
          font-size: 0.8em; /* Adjust the value as needed */
      }
-    .theme-toggle {
+    .controls {
       position: fixed;
       bottom: 20px;
       left: 20px;
       z-index: 9999;
+      display: flex;
+      gap: 10px;
+    }
+
+    .controls button {
       padding: 10px 16px;
       background-color: rgba(0,0,0,0.6);
       color: #fff;
       border: none;
       border-radius: 8px;
       font-size: 14px;
+      cursor: pointer;
+    }
+
+    .chat-modal {
+      display: none;
+      position: fixed;
+      z-index: 10000;
+      left: 0;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      background-color: rgba(0,0,0,0.5);
+    }
+
+    .chat-content {
+      background-color: #fff;
+      margin: 10% auto;
+      padding: 20px;
+      border-radius: 8px;
+      width: 90%;
+      max-width: 400px;
+      color: #000;
+    }
+
+    .chat-content .close {
+      float: right;
+      font-size: 20px;
       cursor: pointer;
     }
 
@@ -237,7 +269,26 @@
     </div>
   </div>
 
-  <button class="theme-toggle" onclick="toggleTheme()">🌓 Zmień motyw</button>
+  <div class="controls">
+    <button onclick="toggleTheme()">🌓 Zmień motyw</button>
+    <button onclick="openChat()">🤖 Zapytaj AI</button>
+  </div>
+
+  <div id="chatModal" class="chat-modal">
+    <div class="chat-content">
+      <span class="close" onclick="closeChat()">&times;</span>
+      <div id="apiKeySection">
+        <h3>Wprowadź Gemini API Key</h3>
+        <input type="password" id="apiKeyInput" placeholder="API Key" />
+        <button onclick="saveApiKey()">Zapisz</button>
+      </div>
+      <div id="chatSection" style="display: none;">
+        <div id="chatMessages" style="max-height:300px; overflow-y:auto; margin-bottom:10px;"></div>
+        <input type="text" id="chatInput" placeholder="Twoje pytanie" style="width:100%; box-sizing:border-box; margin-bottom:10px;" />
+        <button onclick="sendMessage()">Wyślij</button>
+      </div>
+    </div>
+  </div>
 
   <!-- JS z Reveal i pluginami -->
   <script src="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/reveal.min.js"></script>
@@ -264,6 +315,63 @@
       } else {
         link.setAttribute("href", "https://cdn.jsdelivr.net/npm/reveal.js@4/dist/theme/white.css");
       }
+    }
+
+    function openChat() {
+      const modal = document.getElementById('chatModal');
+      const apiKey = localStorage.getItem('gemini_api_key');
+      modal.style.display = 'block';
+      if (apiKey) {
+        document.getElementById('apiKeySection').style.display = 'none';
+        document.getElementById('chatSection').style.display = 'block';
+      } else {
+        document.getElementById('apiKeySection').style.display = 'block';
+        document.getElementById('chatSection').style.display = 'none';
+      }
+    }
+
+    function closeChat() {
+      document.getElementById('chatModal').style.display = 'none';
+    }
+
+    function saveApiKey() {
+      const key = document.getElementById('apiKeyInput').value.trim();
+      if (key) {
+        localStorage.setItem('gemini_api_key', key);
+        document.getElementById('apiKeySection').style.display = 'none';
+        document.getElementById('chatSection').style.display = 'block';
+      }
+    }
+
+    let chatHistory = [];
+
+    async function sendMessage() {
+      const apiKey = localStorage.getItem('gemini_api_key');
+      if (!apiKey) {
+        openChat();
+        return;
+      }
+      const inputEl = document.getElementById('chatInput');
+      const text = inputEl.value.trim();
+      if (!text) return;
+      const messagesEl = document.getElementById('chatMessages');
+      messagesEl.innerHTML += `<div><strong>Ty:</strong> ${text}</div>`;
+      chatHistory.push({ role: 'user', parts: [{ text }] });
+      inputEl.value = '';
+      try {
+        const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${apiKey}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ contents: chatHistory })
+        });
+        const data = await res.json();
+        const reply = data.candidates?.[0]?.content?.parts?.[0]?.text || 'Brak odpowiedzi';
+        messagesEl.innerHTML += `<div><strong>AI:</strong> ${reply}</div>`;
+        chatHistory.push({ role: 'model', parts: [{ text: reply }] });
+      } catch (e) {
+        messagesEl.innerHTML += `<div><strong>AI:</strong> Wystąpił błąd.</div>`;
+      }
+      messagesEl.scrollTop = messagesEl.scrollHeight;
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add bottom control panel with theme and "Zapytaj AI" buttons
- persist Gemini API key and expose modal chat interface
- send user prompts to Gemini API and display responses

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68934b5d45a48331848b87cede357665