### PR TITLE
feat: disable send while waiting and render markup

### DIFF
--- a/gemini.js
+++ b/gemini.js
@@ -47,6 +47,9 @@ let chatHistory = [
 let isWaiting = false;
 
 function formatMessage(text) {
+  if (window.marked) {
+    return marked.parse(text);
+  }
   return text
     .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
     .replace(/\n/g, '<br>');
@@ -97,7 +100,6 @@ async function sendMessage() {
   chatHistory.push({ role: 'user', parts: [{ text }] });
   inputEl.value = '';
   sendBtn.disabled = true;
-  inputEl.disabled = true;
   isWaiting = true;
   try {
     const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${apiKey}`, {
@@ -119,7 +121,6 @@ async function sendMessage() {
     messagesEl.appendChild(errorDiv);
   } finally {
     sendBtn.disabled = false;
-    inputEl.disabled = false;
     isWaiting = false;
     messagesEl.scrollTop = messagesEl.scrollHeight;
   }

--- a/index.html
+++ b/index.html
@@ -380,6 +380,7 @@
       }
     }
   </script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="gemini.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- parse Gemini's markdown replies using marked for richer formatting
- keep send button disabled while awaiting a response

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893ae6b26ac8331aeceb6e0de8ebc19