### PR TITLE
Add introduction slide with personal profile

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,6 +170,12 @@
 <body>
   <div class="reveal">
     <div class="slides">
+      <section>
+        <h2>👤 O mnie</h2>
+        <p>Borys – pasjonat latania i planowania podróży, ok. 400 lotów.</p>
+        <p>Więcej statystyk: <a href="https://openflights.org/user/boryzo" target="_blank" rel="noopener">openflights.org/user/boryzo</a></p>
+        <iframe src="https://openflights.org/user/boryzo/map" style="width:80%; height:400px; border:2px solid #ccc; display:block; margin:20px auto 0;" loading="lazy"></iframe>
+      </section>
       <section data-bg-random="images/airport.png,images/airport2.png" data-background-size="cover" data-background-opacity="0.3">
         <h1>🌍 Travel Hacking</h1>
         <h3>Jak podróżować sprytniej, taniej i wygodniej</h3>


### PR DESCRIPTION
## Summary
- add introductory slide about Borys with link to OpenFlights profile
- embed OpenFlights map via iframe instead of committing binary screenshot

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a5083e32c833199593b1f3f01624a